### PR TITLE
Allow configuring scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ scrape_configs:
       apiKey: [ 'YOUR-APIKEY-HERE' ]
 ```
 
+It also supports an optional `scheme` URL parameter, that defaults to `https`.
+Set it to `http` if you want to access API without TLS encryption.
+
 ## Example metrics
 
 ```

--- a/mailcowApi/client.go
+++ b/mailcowApi/client.go
@@ -14,6 +14,7 @@ import (
 
 // Client for mailcow API
 type MailcowApiClient struct {
+	Scheme       string
 	Host         string
 	ApiKey       string
 	ResponseTime prometheus.GaugeVec
@@ -21,8 +22,9 @@ type MailcowApiClient struct {
 	Success      prometheus.GaugeVec
 }
 
-func NewMailcowApiClient(host string, apiKey string) MailcowApiClient {
+func NewMailcowApiClient(scheme string, host string, apiKey string) MailcowApiClient {
 	return MailcowApiClient{
+		Scheme: scheme,
 		Host:   host,
 		ApiKey: apiKey,
 		ResponseTime: *prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -47,7 +49,7 @@ func NewMailcowApiClient(host string, apiKey string) MailcowApiClient {
 // with the correct authentication and unserialize the JSON
 // response into a given target reference.
 func (api MailcowApiClient) Get(endpoint string, target interface{}) error {
-	url := fmt.Sprintf("https://%s/%s", api.Host, endpoint)
+	url := fmt.Sprintf("%s://%s/%s", api.Scheme, api.Host, endpoint)
 	log.Print(url)
 
 	request, err := http.NewRequest("GET", url, nil)

--- a/main.go
+++ b/main.go
@@ -37,8 +37,8 @@ var (
 	}
 )
 
-func collectMetrics(host string, apiKey string) *prometheus.Registry {
-	apiClient := mailcowApi.NewMailcowApiClient(host, apiKey)
+func collectMetrics(scheme string, host string, apiKey string) *prometheus.Registry {
+	apiClient := mailcowApi.NewMailcowApiClient(scheme, host, apiKey)
 
 	success := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name:        "mailcow_exporter_success",
@@ -92,13 +92,17 @@ func main() {
 	http.HandleFunc("/metrics", func(response http.ResponseWriter, request *http.Request) {
 		host := request.URL.Query().Get("host")
 		apiKey := request.URL.Query().Get("apiKey")
+		scheme := request.URL.Query().Get("scheme")
 		if host == "" || apiKey == "" {
 			response.WriteHeader(http.StatusBadRequest)
 			response.Write([]byte("Query parameters `host` & `apiKey` are required"))
 			return
 		}
+		if scheme == "" {
+			scheme = "https"
+		}
 
-		registry := collectMetrics(host, apiKey)
+		registry := collectMetrics(scheme, host, apiKey)
 
 		promhttp.HandlerFor(
 			registry,


### PR DESCRIPTION
The current setup hardcodes `https` scheme, which forces me to configure `mailcow-exporter` to talk to mailcow via public endpoint.

I prefer to simply put `mailcow-exporter` in the same docker network and point it to `nginx-mailcow` container directly.

Because I handle `https` on reverse proxy level, this nginx container can only talk `http`.

This PR will allow me to make `mailcow-exporter` talk `http` 🙂 