### PR TITLE
[CVE] Fix vulnerabilities by updating alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN cd /build \
     && go build -o /mailcow-exporter /build/main.go \
     && rm -Rf /build
 
-FROM alpine:3.13
+FROM alpine:3.15
 
 RUN apk add --no-cache \
         openssl \


### PR DESCRIPTION
Hello @j6s,

First of all, thanks for providing this fantastic open-source project. I use it myself with the Grafana dashboard.

The vulnerability scanner from [armosec](https://hub.armo.cloud/docs/cluster-vulnerability-scanning) found 14 vulnerabilities in your image. They originate from an outdated version of alpine.

These vulnerabilities are related to: `apk-tools`, `openssl` and `busybox`

Found vulnerabilities (selection): CVE-2021-36159, CVE-2021-3711, CVE-2021-42378

I would really appreciate if you could merge the PR and create a new Docker tag as soon as you have time for it.
