### PR TITLE
fix panic by handling error message

### DIFF
--- a/mailcowApi/client.go
+++ b/mailcowApi/client.go
@@ -67,6 +67,14 @@ func (api MailcowApiClient) Get(endpoint string, target interface{}) error {
 
 	// API Request
 	response, err := (&http.Client{}).Do(request)
+	if err != nil {
+		api.Success.WithLabelValues(endpoint).Set(0.0)
+		return fmt.Errorf(
+			"could not execute API request to `%s`: %#v",
+			endpoint,
+			err.Error(),
+		)
+	}
 
 	// Metric collection about the API request
 	statusCodeString := strconv.FormatInt(int64(response.StatusCode), 10)


### PR DESCRIPTION
This PR for addressing panic message below:

```
2022/09/03 09:15:13 http: panic serving [::1]:50741: runtime error: invalid memory address or nil pointer dereference
goroutine 146 [running]:
net/http.(*conn).serve.func1()
	/opt/homebrew/Cellar/go/1.19/libexec/src/net/http/server.go:1850 +0xb0
panic({0x100c77440, 0x100fb0230})
```