### PR TITLE
fix a missing label change

### DIFF
--- a/provider/domain.go
+++ b/provider/domain.go
@@ -40,7 +40,7 @@ func (domain Domain) Provide(api mailcowApi.MailcowApiClient) ([]prometheus.Coll
 	maxAliases := domainGauge("mailcow_domain_max_aliases", "Maximum amount of aliases for the domain", api.Host)
 	quotaAllowed := domainGauge("mailcow_domain_quota_allowed", "Aggregate quota maximum for the domain in bytes", api.Host)
 	quotaUsed := domainGauge("mailcow_domain_quota_used", "Current size of the domain in bytes", api.Host)
-	messages := domainGauge("mailcow_mailbox_messages", "Number of messages in for the domain mailboxes", api.Host)
+	messages := domainGauge("mailcow_domain_messages", "Number of messages in for the domain mailboxes", api.Host)
 	collectors := []prometheus.Collector{active, mailboxes, maxMailboxes, aliases, maxAliases, quotaAllowed, quotaUsed, messages}
 
 	body := make([]domainItem, 0)


### PR DESCRIPTION
this fix to address this:

```
a previously registered descriptor with the same fully-qualified name as Desc{fqName: "mailcow_mailbox_messages", help: "Number of messages in for the domain mailboxes", constLabels: {host="mail server"}, variableLabels: [domain]} has different label names or a different help string
```