### PR TITLE
Feature: Set Host and API Key via flags or environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ scrape_configs:
 It also supports an optional `scheme` URL parameter, that defaults to `https`.
 Set it to `http` if you want to access API without TLS encryption.
 
+### Setting host or api key on application start-up
+
+When using the exporter for a single mailcow host, it might be useful not to send `host` and `apiKey` with every request, since they don't change.
+Hence the API Key or Host can be set on application startup using flags or environment variables.
+
+The host can be set using the flag `host` or the environment variable `MCE_HOST`. If both items are set, the flag wins.
+
+The API Key can be set using the flag `apikey` or the environment variable `MCE_API_KEY`. If both items are set, the flag wins.
+
+**NOTE**: When using this, it might be a good idea to restrict access to the exporter via localhost (set `listen` flag to `127.0.0.1:9099` or `::1:9099`) or to restrict access to a local network, but not to bind the port on all interfaces.
+
 ## Example metrics
 
 ```

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/j6s/mailcow-exporter/mailcowApi"
 	"github.com/j6s/mailcow-exporter/provider"
@@ -43,12 +44,27 @@ var (
 	}
 )
 
+func setupParametersFromEnv() {
+	if defaultHost == "" {
+		if env_host, present := os.LookupEnv("MCE_HOST"); present {
+			defaultHost = env_host
+		}
+	}
+
+	if defaultApiKey == "" {
+		if env_api_key, present := os.LookupEnv("MCE_API_KEY"); present {
+			defaultApiKey = env_api_key
+		}
+	}
+}
+
 func parseFlagsAndEnv() {
 	flag.StringVar(&defaultHost, "host", "", "The host to connect to.")
 	flag.StringVar(&defaultApiKey, "apikey", "", "The API key to use for connection")
 
 	flag.Parse()
 
+	setupParametersFromEnv()
 }
 
 func collectMetrics(scheme string, host string, apiKey string) *prometheus.Registry {

--- a/main.go
+++ b/main.go
@@ -17,6 +17,11 @@ var (
 	listen = flag.String("listen", ":9099", "Host and port to listen on")
 )
 
+var (
+	defaultHost   string
+	defaultApiKey string
+)
+
 // A Provider is the common abstraction over collection of metrics in this
 // exporter. It can provide one or more prometheus collectors (e.g. gauges,
 // histograms, ...) that are updated every time the `Update` method is called.
@@ -37,6 +42,14 @@ var (
 		provider.Domain{},
 	}
 )
+
+func parseFlagsAndEnv() {
+	flag.StringVar(&defaultHost, "host", "", "The host to connect to.")
+	flag.StringVar(&defaultApiKey, "apikey", "", "The API key to use for connection")
+
+	flag.Parse()
+
+}
 
 func collectMetrics(scheme string, host string, apiKey string) *prometheus.Registry {
 	apiClient := mailcowApi.NewMailcowApiClient(scheme, host, apiKey)
@@ -88,7 +101,7 @@ func collectMetrics(scheme string, host string, apiKey string) *prometheus.Regis
 }
 
 func main() {
-	flag.Parse()
+	parseFlagsAndEnv()
 
 	http.HandleFunc("/metrics", func(response http.ResponseWriter, request *http.Request) {
 		host := request.URL.Query().Get("host")

--- a/main.go
+++ b/main.go
@@ -134,12 +134,15 @@ func main() {
 			scheme = "https"
 		}
 
+		if host == "" {
 			response.WriteHeader(http.StatusBadRequest)
-			response.Write([]byte("Query parameters `host` & `apiKey` are required"))
+			response.Write([]byte("Query parameter `host` is required, since it is not defined by flags or environment"))
 			return
 		}
-		if scheme == "" {
-			scheme = "https"
+		if apiKey == "" {
+			response.WriteHeader(http.StatusUnauthorized)
+			response.Write([]byte("Query parameter `apiKey` is required, since it is not defined by flags or environment"))
+			return
 		}
 
 		registry := collectMetrics(scheme, host, apiKey)

--- a/main.go
+++ b/main.go
@@ -107,7 +107,17 @@ func main() {
 		host := request.URL.Query().Get("host")
 		apiKey := request.URL.Query().Get("apiKey")
 		scheme := request.URL.Query().Get("scheme")
-		if host == "" || apiKey == "" {
+
+		if host == "" {
+			host = defaultHost
+		}
+		if apiKey == "" {
+			apiKey = defaultApiKey
+		}
+		if scheme == "" {
+			scheme = "https"
+		}
+
 			response.WriteHeader(http.StatusBadRequest)
 			response.Write([]byte("Query parameters `host` & `apiKey` are required"))
 			return


### PR DESCRIPTION
## Why has this pull request beed created?

I use mailcow-exporter as a workaround for [the missing support within mailcow itself](https://github.com/mailcow/mailcow-dockerized/issues/1695).

If only one mailcow instance is mirrored, it might be a wise idea to put this exporter to into the same network and application stack using `docker-compose.override.yml` and add an endpoint to the prometheus scraper on the same host or a neighbored host.

In this case, the host is known AND the API Key should not leave the application stack. Therefore it is a good idea to keep both secret and not to share them with the scraper.

## What does this pull request do?

It adds an implementation, so that both - host and API Key - can be set during application startup phase using either flags (host or apikey) or environment variables (MCE_HOST and MCE_API_KEY, where MCE is short for **M**ail**C**ow-**E**xporter).

## Are there alternatives?

I'm using traefik as reverse proxy for my mailcow application stack. Unfortunately, it does not allow modifying the query parameters, using a path replacement does not work either, since the ampersand (`&`) will be url encoded. The middleware to replace, add or delete parameters is still [pending](https://github.com/traefik/traefik/issues/6276).

## What has been done?

- [X] Adjust implementation
- [ ] ~Write tests~ (There are not tests to adjust yet.
- [X] Do a manual test
- [X] Update documentation (`ReadMe.md`)